### PR TITLE
Set check mode to prevent role from failing in check mode

### DIFF
--- a/tasks/manage/capture_cluster_resource_info.yml
+++ b/tasks/manage/capture_cluster_resource_info.yml
@@ -4,6 +4,7 @@
   register: _pcs_version
   changed_when: false
   failed_when: false
+  check_mode: false
 
 - name: pcs version < 0.10.0
   when: _pcs_version.stdout is version('0.10.0', '<')
@@ -13,6 +14,7 @@
       register: _try_pcs_resource_show
       changed_when: false
       failed_when: false
+      check_mode: false
 
     - name: try capturing stopped cluster resource (<0.10.0)
       when: _try_pcs_resource_show.rc != 0
@@ -22,6 +24,7 @@
           register: _try_pcs_resource_show_stopped
           changed_when: false
           failed_when: false
+          check_mode: false
 
 - name: pcs version >= 0.10.0
   when: _pcs_version.stdout is version('0.10.0', '>=')
@@ -31,6 +34,7 @@
       register: _try_pcs_resource_config
       changed_when: false
       failed_when: false
+      check_mode: false
 
 - name: update _pcs_resource_config
   ansible.builtin.set_fact:


### PR DESCRIPTION
I've been using the role run with check mode recently and discovered that it will fail to run.

## Check run output

```
TASK [skriptfabrik.pacemaker : capturing cluster resource (<0.10.0)] ***********
Friday 07 October 2022  07:23:06 +0000 (0:00:00.343)       0:00:35.621 ******** 
fatal: [lb-0]: FAILED! => 
  msg: |-
    The conditional check '_pcs_version.stdout is version('0.10.0', '<')' failed. The error was: Input version value cannot be empty
  
    The error appears to be in '/builds/ansible/lbs/roles/vendor/skriptfabrik.pacemaker/tasks/manage/capture_cluster_resource_info.yml': line 11, column 7, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
      block:
        - name: capturing cluster resource (<0.10.0)
          ^ here
```

Adding `check_mode` setting will allow the tasks to run - since they are not making changes to the target systems that should be acceptable - and thus makes dry runs work.