### PR TITLE
Fix/ansible lint action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,7 +42,7 @@ jobs:
     name: Run Molecule Tests
     defaults:
       run:
-        working-directory: skriptfabrik.pacemaker
+        working-directory: ~/.ansible/roles/skriptfabrik.pacemaker
     needs:
       - lint
     runs-on: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
         with:
-          path: skriptfabrik.pacemaker
+          path: ~/.ansible/roles/skriptfabrik.pacemaker
 
       - name: Set up Python 3.
         uses: actions/setup-python@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,7 +42,7 @@ jobs:
     name: Run Molecule Tests
     defaults:
       run:
-        working-directory: ~/.ansible/roles/skriptfabrik.pacemaker
+        working-directory: skriptfabrik.pacemaker
     needs:
       - lint
     runs-on: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
         with:
-          path: ~/.ansible/roles/skriptfabrik.pacemaker
+          path: skriptfabrik.pacemaker
 
       - name: Set up Python 3.
         uses: actions/setup-python@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,7 +26,7 @@ jobs:
         uses: frenck/action-yamllint@v1
 
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@v6.17.0
+        uses: ansible/ansible-lint@v26
 
       - name: Cache Ansible collections
         uses: actions/cache@v4

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,6 +4,13 @@ rules:
   line-length:
     max: 160
     level: warning
-  comments: disable
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 ignore: |
   .github/

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -7,4 +7,4 @@
         name:
           - nginx
         update_cache: true
-      when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+      when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -7,13 +7,13 @@
       ansible.builtin.apt:
         name: pacemaker
         state: present
-      when: ansible_os_family == "Debian"
+      when: ansible_facts["os_family"] == "Debian"
 
     - name: Install Pacemaker on RHEL/CentOS
       ansible.builtin.dnf:
         name: pacemaker
         state: present
-      when: ansible_os_family == "RedHat"
+      when: ansible_facts["os_family"] == "RedHat"
 
 - name: Verify Pacemaker service is running
   hosts: all

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,4 @@
 ---
-roles:
-  - name: skriptfabrik.pacemaker
-    src: https://github.com/skriptfabrik/ansible-role-pacemaker.git
 collections:
   - name: ansible.posix
   - name: community.general

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -47,7 +47,9 @@
           loop_control:
             loop_var: cluster_resource
             label: "{{ cluster_resource.resource_id }}"
-          when: cluster_resource.resource_id | regex_search('^service.*') is not none
+          when:
+            - cluster_resource.resource_id is defined
+            - cluster_resource.resource_id is match("^service.*")
           failed_when: false
           ansible.builtin.command: pcs resource restart {{ cluster_resource.resource_id }}
           changed_when: "command_result.rc == 0"

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -47,7 +47,7 @@
           loop_control:
             loop_var: cluster_resource
             label: "{{ cluster_resource.resource_id }}"
-          when: cluster_resource.resource_id | regex_search('^service.*')
+          when: cluster_resource.resource_id | regex_search('^service.*') is not none
           failed_when: false
           ansible.builtin.command: pcs resource restart {{ cluster_resource.resource_id }}
           changed_when: "command_result.rc == 0"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Setting facts
   ansible.builtin.set_fact:
-    corosync_bindnet_addr: "{{ hostvars[inventory_hostname]['ansible_' + corosync_bindnet_interface]['ipv4']['address'] }}"
+    corosync_bindnet_addr: "{{ ansible_facts[corosync_bindnet_interface]['ipv4']['address'] }}"
 
 - name: Capturing corosync auth key
   when: inventory_hostname == pacemaker_primary_server
@@ -26,7 +26,7 @@
         dest: "{{ corosync_authkey_file }}"
         owner: root
         group: root
-        mode: 0600
+        mode: "0600"
 
 - name: Configuring corosync
   notify:
@@ -38,7 +38,7 @@
     dest: "{{ corosync_config_file }}"
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
 
 - name: Configuring corosync service to start
   notify:
@@ -49,7 +49,7 @@
     dest: /etc/default/corosync
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
 
 - name: Force handlers to run
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Replace deprecated `ansible-community/ansible-lint-action@v6.17.0` with the official successor `ansible/ansible-lint@v26`.